### PR TITLE
Work around a bug in latest pyvis

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 packages = find:
 install_requires =
     pyyaml
-    pyvis
+    pyvis >= 0.3.2
 
 [options.extras_require]
 test =

--- a/visual_excuses/main.py
+++ b/visual_excuses/main.py
@@ -284,6 +284,6 @@ def main(args=None):
         graph.save_graph(opts.save)
         return 0
 
-    graph.show("excuses.html")
+    graph.show("excuses.html", notebook=False)
 
     return 0


### PR DESCRIPTION
Latest pyvis introduced the notebook kw parameter to Graph.show(), but it crashes for us with the default value of notebook=True. To work around the issue I could either pin the dependency to the previous version or explicitly set the value to False while enforcing using the most recent version. THe latter approach has the advantage of being forward-compatible with future versions of the package (assuming they don't break API!!)