### PR TITLE
Use entire viewport

### DIFF
--- a/visual_excuses/main.py
+++ b/visual_excuses/main.py
@@ -152,7 +152,7 @@ def create_visual_excuses(data, team_choice='', age=0):
 
     default_color = '#FFFFFF'
 
-    visual_excuses = Network(height="768px", width="1024px", directed=True)
+    visual_excuses = Network(height="100vh", width="100vw", directed=True)
 
     for item in data.values():
         current_package = item['name']


### PR DESCRIPTION
Until now the `visual-excuse` tool only used a 768x1024px viewport to visualize the graph.

This PR proposes to use the entire viewport of the browser to get a better overview.

For everyone unfamiliar with the CSS units `vh` and `vw`:
- `100vh` is 100% of the height of the viewport of the browser window. This is different from `100%` which will only use 100% height of the parents height.
- it's the same for `100vw` just for the width

Note that there will be a scroll bar displayed for horizontal and vertical scrolling as the width/height of the parent is slightly larger than the html element that contains the graph element. I think this is fine, as a the usability added outweighs this minor visual artifact.