### PR TITLE
Ubuntu excuses Command Line Interface

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ test =
 [options.entry_points]
 console_scripts =
     visual-excuses = visual_excuses.main:main
+    ubuntu-excuses = visual_excuses.ubuntu_excuses_cli:main
 
 [tool:pytest]
 addopts = --cov

--- a/visual_excuses/excuse.py
+++ b/visual_excuses/excuse.py
@@ -16,7 +16,7 @@ class Excuse:
         excuse_bug (str) : LaunchPad bug relevant to that excuse
         blocked_by (str) : excuse blocking this excuse to migrate
         migrate_after (List) : excuses that need to migrate before this excuse
-        excuses (List) : Text List of all excuses (autopkgtest and dependencies)
+        excuses (List) : List of all excuses (autopkgtest and dependencies)
     """
 
     item_name: str

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -19,6 +19,12 @@ class ExcusesParser:
         )
 
         self.parser.add_argument(
+            "--component",
+            type=str,
+            help="Archive component (main, restricted, universe, multivere)"
+        )
+
+        self.parser.add_argument(
             "--team",
             type=str,
             help="Show only packages subscribed by this Ubuntu team"

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -7,27 +7,15 @@ class ExcusesParser:
             description="Ubuntu Excuses (Proposed Migration) Viewer")
 
         self.parser.add_argument(
-            "--ftbfs",
-            action="store_true",
-            help="Show only FTBFS packages"
-        )
-
-        self.parser.add_argument(
-            "--json",
-            action="store_true",
-            help="Output in JSON format"
-        )
-
-        self.parser.add_argument(
-            "--limit",
-            type=int,
-            help="Limit the number of results shown"
-        )
-
-        self.parser.add_argument(
             "--name",
             type=str,
             help="Regex to filter package names (case-insensitive)"
+        )
+
+        self.parser.add_argument(
+            "--ftbfs",
+            action="store_true",
+            help="Show only FTBFS packages"
         )
 
         self.parser.add_argument(
@@ -40,6 +28,18 @@ class ExcusesParser:
             "--max-age",
             type=int,
             help="Only include packages no older than this many days"
+        )
+
+        self.parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of results shown"
+        )
+
+        self.parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Output in JSON format"
         )
 
     def parse_args(self, argv=None):

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -24,6 +24,12 @@ class ExcusesParser:
             help="Limit the number of results shown"
         )
 
+        self.parser.add_argument(
+            "--name",
+            type=str,
+            help="Regex to filter package names (case-insensitive)"
+        )
+
     def parse_args(self, argv=None):
         self.args = self.parser.parse_args(argv)
         return self.args

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -7,6 +7,12 @@ class ExcusesParser:
             description="Ubuntu Excuses (Proposed Migration) Viewer")
 
         self.parser.add_argument(
+            "--inspect",
+            type=str,
+            help="Get details about a specific package"
+        )
+
+        self.parser.add_argument(
             "--name",
             type=str,
             help="Regex to filter package names (case-insensitive)"

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -55,6 +55,12 @@ class ExcusesParser:
         )
 
         self.parser.add_argument(
+            "--reverse",
+            action="store_true",
+            help="Show excuses from older to more recent"
+        )
+
+        self.parser.add_argument(
             "--json",
             action="store_true",
             help="Output in JSON format"

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -19,6 +19,12 @@ class ExcusesParser:
         )
 
         self.parser.add_argument(
+            "--team",
+            type=str,
+            help="Show only packages subscribed by this Ubuntu team"
+        )
+
+        self.parser.add_argument(
             "--ftbfs",
             action="store_true",
             help="Show only FTBFS packages"

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -30,6 +30,18 @@ class ExcusesParser:
             help="Regex to filter package names (case-insensitive)"
         )
 
+        self.parser.add_argument(
+            "--min-age",
+            type=int,
+            help="Only include packages at least this many days old"
+        )
+
+        self.parser.add_argument(
+            "--max-age",
+            type=int,
+            help="Only include packages no older than this many days"
+        )
+
     def parse_args(self, argv=None):
         self.args = self.parser.parse_args(argv)
         return self.args

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -1,0 +1,29 @@
+import argparse
+
+
+class ExcusesParser:
+    def __init__(self):
+        self.parser = argparse.ArgumentParser(
+            description="Ubuntu Excuses (Proposed Migration) Viewer")
+
+        self.parser.add_argument(
+            "--ftbfs",
+            action="store_true",
+            help="Show only FTBFS packages"
+        )
+
+        self.parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Output in JSON format"
+        )
+
+        self.parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limit the number of results shown"
+        )
+
+    def parse_args(self, argv=None):
+        self.args = self.parser.parse_args(argv)
+        return self.args

--- a/visual_excuses/table_visual.py
+++ b/visual_excuses/table_visual.py
@@ -1,0 +1,21 @@
+from visual_excuses.excuse import Excuse
+from typing import List
+from tabulate import tabulate
+
+
+def render_excuses_table(excuses: List[Excuse]) -> str:
+    """Render a list of Excuse objects as a table."""
+
+    headers = ["Days", "Package", "Component", "New Version", "FTBFS"]
+    rows = [
+        [
+            e.age,
+            e.item_name,
+            e.component,
+            e.new_version,
+            "✅" if e.ftbfs() else ""
+        ]
+        for e in excuses
+    ]
+
+    return tabulate(rows, headers=headers, tablefmt="fancy_grid")

--- a/visual_excuses/table_visual.py
+++ b/visual_excuses/table_visual.py
@@ -6,14 +6,21 @@ from tabulate import tabulate
 def render_excuses_table(excuses: List[Excuse]) -> str:
     """Render a list of Excuse objects as a table."""
 
-    headers = ["Days", "Package", "Component", "New Version", "FTBFS"]
+    headers = [
+            "Days",
+            "Package",
+            "Component",
+            "New Version",
+            "FTBFS",
+            "Excuse Bug"]
     rows = [
         [
             e.age,
             e.item_name,
             e.component,
             e.new_version,
-            "✅" if e.ftbfs() else ""
+            "✅" if e.ftbfs() else "",
+            e.excuse_bug
         ]
         for e in excuses
     ]

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -4,6 +4,7 @@
 from visual_excuses.ubuntu_excuses_loader import load_ubuntu_excuses
 from visual_excuses.table_visual import render_excuses_table
 from visual_excuses.excuses_parser import ExcusesParser
+from visual_excuses.ubuntu_teams import UbuntuTeamMapping
 
 import json
 import re
@@ -42,6 +43,17 @@ def main():
         excuses = [
             e for e in excuses if e.age is not None and e.age <= args.max_age
         ]
+
+    if args.team:
+        ubuntu_teams = UbuntuTeamMapping()
+        if args.team in ubuntu_teams.mapping:
+            excuses = [
+                e for e in excuses
+                if ubuntu_teams.default_team(e.item_name) == args.team
+            ]
+        else:
+            print(f"Team {args.team} is not a valid Ubuntu Team")
+            return
 
     if args.name:
         try:

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -18,6 +18,18 @@ def main():
 
     excuses = load_ubuntu_excuses()
 
+    if args.inspect:
+        excuse = next(
+            (e for e in excuses if e.item_name == args.inspect), None
+        )
+        if excuse:
+            print(render_excuses_table([excuse]))
+            print(json.dumps(excuse.__dict__, indent=2))
+            return
+        else:
+            print(f"Excuse {args.inspect} can't be found in excuses list")
+            return
+
     if args.ftbfs:
         excuses = [e for e in excuses if e.ftbfs()]
 

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -1,0 +1,33 @@
+# excuses: simple command line tool allowing to manipulate current list of
+# packages stuck in the proposed pocket and not migrating to Ubuntu Devel
+
+from visual_excuses.ubuntu_excuses_loader import load_ubuntu_excuses
+from visual_excuses.table_visual import render_excuses_table
+from visual_excuses.excuses_parser import ExcusesParser
+
+import json
+
+
+def main():
+    """
+    For now the main function will simply list all the excuses on Ubuntu Devel
+    """
+    parser = ExcusesParser()
+    args = parser.parse_args()
+
+    excuses = load_ubuntu_excuses()
+
+    if args.ftbfs:
+        excuses = [e for e in excuses if e.ftbfs()]
+
+    if args.limit:
+        excuses = excuses[:args.limit]
+
+    if args.json:
+        print(json.dumps([e.__dict__ for e in excuses], indent=2))
+    else:
+        print(render_excuses_table(excuses))
+
+
+if __name__ == "__main__":
+    main()

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -6,7 +6,7 @@ from visual_excuses.table_visual import render_excuses_table
 from visual_excuses.excuses_parser import ExcusesParser
 
 import json
-
+import re
 
 def main():
     """
@@ -22,6 +22,14 @@ def main():
 
     if args.limit:
         excuses = excuses[:args.limit]
+
+    if args.name:
+        try:
+            pattern = re.compile(args.name, re.IGNORECASE)
+            excuses = [e for e in excuses if pattern.search(e.item_name)]
+        except re.error as e:
+            print(f"Invalid regex pattern: {e}")
+            return
 
     if args.json:
         print(json.dumps([e.__dict__ for e in excuses], indent=2))

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -71,6 +71,9 @@ def main():
     if args.limit:
         excuses = excuses[:args.limit]
 
+    if args.reverse:
+        excuses.reverse()
+
     if args.json:
         print(json.dumps([e.__dict__ for e in excuses], indent=2))
     else:

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -8,6 +8,7 @@ from visual_excuses.excuses_parser import ExcusesParser
 import json
 import re
 
+
 def main():
     """
     For now the main function will simply list all the excuses on Ubuntu Devel
@@ -20,8 +21,15 @@ def main():
     if args.ftbfs:
         excuses = [e for e in excuses if e.ftbfs()]
 
-    if args.limit:
-        excuses = excuses[:args.limit]
+    if args.min_age is not None:
+        excuses = [
+            e for e in excuses if e.age is not None and e.age >= args.min_age
+        ]
+
+    if args.max_age is not None:
+        excuses = [
+            e for e in excuses if e.age is not None and e.age <= args.max_age
+        ]
 
     if args.name:
         try:
@@ -30,6 +38,9 @@ def main():
         except re.error as e:
             print(f"Invalid regex pattern: {e}")
             return
+
+    if args.limit:
+        excuses = excuses[:args.limit]
 
     if args.json:
         print(json.dumps([e.__dict__ for e in excuses], indent=2))

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -55,6 +55,11 @@ def main():
             print(f"Team {args.team} is not a valid Ubuntu Team")
             return
 
+    if args.component:
+        excuses = [
+            e for e in excuses if e.component == args.component
+        ]
+
     if args.name:
         try:
             pattern = re.compile(args.name, re.IGNORECASE)

--- a/visual_excuses/ubuntu_teams.py
+++ b/visual_excuses/ubuntu_teams.py
@@ -1,0 +1,30 @@
+import requests
+from typing import List
+
+UBUNTU_TEAMS_MAPPING_URL = (
+    "http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.json"
+)
+
+
+class UbuntuTeamMapping:
+    def __init__(self):
+        # retrieve distro teams and packages information
+        response = requests.get(UBUNTU_TEAMS_MAPPING_URL)
+        if response.status_code == 200:
+            self.mapping = response.json()
+        else:
+            raise RuntimeError("Failed to load Ubuntu team mapping.")
+
+    def get_teams(self, package: str) -> List[str]:
+        # return teams assigned to a single package
+        teams = []
+        for team, packages in self.mapping.items():
+            if package in packages:
+                teams.append(team)
+
+        return teams
+
+    def default_team(self, package: str) -> str:
+        # This function will return the first team subscribed
+        teams = self.get_teams(package) 
+        return teams[0] if teams else ""

--- a/visual_excuses/yaml_parser.py
+++ b/visual_excuses/yaml_parser.py
@@ -35,7 +35,7 @@ def load_excuses(file_path: str) -> List[Excuse]:
         excuses_list.append(
             Excuse(
                 item_name=entry.get("item-name", ""),
-                component=entry.get("component", ""),
+                component=entry.get("component", "main"),
                 new_version=str(entry.get("new-version", "")),
                 missing_builds=(
                     entry.get("missing-builds", {}).get("on-architectures", [])


### PR DESCRIPTION
provides full feature ubuntu-excuses command line with multiple parameters

usage: ubuntu-excuses [-h] [--inspect INSPECT] [--name NAME] [--component COMPONENT] [--team TEAM] [--ftbfs] [--min-age MIN_AGE] [--max-age MAX_AGE] [--limit LIMIT] [--reverse] [--json]

Ubuntu Excuses (Proposed Migration) Viewer

options:
  -h, --help            show this help message and exit
  --inspect INSPECT     Get details about a specific package
  --name NAME           Regex to filter package names (case-insensitive)
  --component COMPONENT     Archive component (main, restricted, universe, multiverse)
  --team TEAM           Show only packages subscribed by this Ubuntu team
  --ftbfs               Show only FTBFS packages
  --min-age MIN_AGE     Only include packages at least this many days old
  --max-age MAX_AGE     Only include packages no older than this many days
  --limit LIMIT         Limit the number of results shown
  --reverse             Show excuses from older to more recent
  --json                Output in JSON format