### PR TITLE
Fix caching

### DIFF
--- a/tests/test_ubuntu_excuses_loader.py
+++ b/tests/test_ubuntu_excuses_loader.py
@@ -24,7 +24,15 @@ sources:
 def test_cache_uncached(tmp_path, excuses_yaml):
     compressed, uncompressed = excuses_yaml
 
-    with patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get:
+    with (
+        patch('visual_excuses.ubuntu_excuses_loader.requests.head') as head,
+        patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get
+    ):
+        response = Mock()
+        response.status_code = 200
+        response.headers = {'ETag': 'foo'}
+        response.raise_for_status.return_value = None
+        head.return_value = response
         response = Mock()
         response.status_code = 200
         response.headers = {'ETag': 'foo'}
@@ -46,7 +54,15 @@ def test_cache_uncached(tmp_path, excuses_yaml):
 def test_cache_cached(tmp_path, excuses_yaml):
     compressed, uncompressed = excuses_yaml
 
-    with patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get:
+    with (
+        patch('visual_excuses.ubuntu_excuses_loader.requests.head') as head,
+        patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get
+    ):
+        response = Mock()
+        response.status_code = 304
+        response.headers = {'ETag': 'foo'}
+        response.raise_for_status.return_value = None
+        head.return_value = response
         response = Mock()
         response.status_code = 304
         response.headers = {'ETag': 'foo'}
@@ -68,7 +84,15 @@ def test_cache_cached(tmp_path, excuses_yaml):
 def test_cache_unexpected(tmp_path, excuses_yaml):
     compressed, uncompressed = excuses_yaml
 
-    with patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get:
+    with (
+        patch('visual_excuses.ubuntu_excuses_loader.requests.head') as head,
+        patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get
+    ):
+        response = Mock()
+        response.status_code = 201
+        response.headers = {'ETag': 'foo'}
+        response.raise_for_status.return_value = None
+        head.return_value = response
         response = Mock()
         response.status_code = 201
         response.headers = {'ETag': 'foo'}
@@ -85,7 +109,15 @@ def test_cache_unexpected(tmp_path, excuses_yaml):
 def test_load_ubuntu_excuses(tmp_path, excuses_yaml):
     compressed, uncompressed = excuses_yaml
 
-    with patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get:
+    with (
+        patch('visual_excuses.ubuntu_excuses_loader.requests.head') as head,
+        patch('visual_excuses.ubuntu_excuses_loader.requests.get') as get
+    ):
+        response = Mock()
+        response.status_code = 200
+        response.headers = {'ETag': 'foo'}
+        response.raise_for_status.return_value = None
+        head.return_value = response
         response = Mock()
         response.status_code = 200
         response.headers = {'ETag': 'foo'}

--- a/tests/test_ubuntu_teams.py
+++ b/tests/test_ubuntu_teams.py
@@ -44,7 +44,7 @@ def test_init_failure_without_connection(tmp_path, mock_requests_get):
 
 
 def test_get_teams_returns_correct_teams_for_package(
-    tmp_path, mock_requests_get):
+        tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200
@@ -89,7 +89,7 @@ def test_default_team_returns_first_team(tmp_path, mock_requests_get):
 
 
 def test_default_team_returns_empty_string_if_no_teams(
-    tmp_path, mock_requests_get):
+        tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200

--- a/tests/test_ubuntu_teams.py
+++ b/tests/test_ubuntu_teams.py
@@ -1,5 +1,8 @@
-import pytest
+import io
+import json
 from unittest.mock import patch, Mock
+
+import pytest
 
 from visual_excuses.ubuntu_teams import UbuntuTeamMapping
 
@@ -8,6 +11,7 @@ FAKE_MAPPING = {
     "team-b": ["gnome", "dbus", "ptyxis"],
     "team-c": ["kernel"]
 }
+FAKE_MAPPING_RAW = json.dumps(FAKE_MAPPING).encode('utf-8')
 
 
 @pytest.fixture
@@ -16,36 +20,39 @@ def mock_requests_get():
         yield mock_get
 
 
-def test_init_succes_with_mapping(mock_requests_get):
+def test_init_succes_with_mapping(tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = FAKE_MAPPING
+    mock_response.headers = {'ETag': 'foo'}
+    mock_response.raw = io.BytesIO(FAKE_MAPPING_RAW)
     mock_requests_get.return_value = mock_response
 
-    team_mapping = UbuntuTeamMapping()
+    team_mapping = UbuntuTeamMapping(cache_dir=tmp_path)
 
     assert (team_mapping.mapping == FAKE_MAPPING)
 
 
-def test_init_failure_without_connection(mock_requests_get):
+def test_init_failure_without_connection(tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 404
     mock_requests_get.return_value = mock_response
 
-    with pytest.raises(RuntimeError, match="Failed to load Ubuntu team "):
-        UbuntuTeamMapping()
+    with pytest.raises(ValueError, match="Unexpected HTTP response "):
+        UbuntuTeamMapping(cache_dir=tmp_path)
 
 
-def test_get_teams_returns_correct_teams_for_package(mock_requests_get):
+def test_get_teams_returns_correct_teams_for_package(
+    tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = FAKE_MAPPING
+    mock_response.headers = {'ETag': 'foo'}
+    mock_response.raw = io.BytesIO(FAKE_MAPPING_RAW)
     mock_requests_get.return_value = mock_response
 
-    team_mapping = UbuntuTeamMapping()
+    team_mapping = UbuntuTeamMapping(cache_dir=tmp_path)
 
     assert team_mapping.get_teams("bash") == ["team-a"]
     assert team_mapping.get_teams("gnome") == ["team-b"]
@@ -53,39 +60,43 @@ def test_get_teams_returns_correct_teams_for_package(mock_requests_get):
 
 
 def test_get_teams_returns_empty_list_teams_for_unknown_package(
-        mock_requests_get):
+        tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = FAKE_MAPPING
+    mock_response.headers = {'ETag': 'foo'}
+    mock_response.raw = io.BytesIO(FAKE_MAPPING_RAW)
     mock_requests_get.return_value = mock_response
 
-    team_mapping = UbuntuTeamMapping()
+    team_mapping = UbuntuTeamMapping(cache_dir=tmp_path)
 
     assert team_mapping.get_teams("vim") == []
 
 
-def test_default_team_returns_first_team(mock_requests_get):
+def test_default_team_returns_first_team(tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = FAKE_MAPPING
+    mock_response.headers = {'ETag': 'foo'}
+    mock_response.raw = io.BytesIO(FAKE_MAPPING_RAW)
     mock_requests_get.return_value = mock_response
 
-    team_mapping = UbuntuTeamMapping()
+    team_mapping = UbuntuTeamMapping(cache_dir=tmp_path)
 
     assert team_mapping.default_team("bash") == "team-a"
     assert team_mapping.default_team("gnome") == "team-b"
     assert team_mapping.default_team("dbus") == "team-a"
 
 
-def test_default_team_returns_empty_string_if_no_teams(mock_requests_get):
+def test_default_team_returns_empty_string_if_no_teams(
+    tmp_path, mock_requests_get):
 
     mock_response = Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = FAKE_MAPPING
+    mock_response.headers = {'ETag': 'foo'}
+    mock_response.raw = io.BytesIO(FAKE_MAPPING_RAW)
     mock_requests_get.return_value = mock_response
 
-    team_mapping = UbuntuTeamMapping()
+    team_mapping = UbuntuTeamMapping(cache_dir=tmp_path)
 
     assert team_mapping.default_team("vim") == ""

--- a/visual_excuses/const.py
+++ b/visual_excuses/const.py
@@ -6,6 +6,10 @@ UBUNTU_EXCUSES_URL = (
     "update_excuses.yaml.xz"
 )
 
+UBUNTU_TEAMS_MAPPING_URL = (
+    "http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.json"
+)
+
 CACHE_HOME = os.environ.get('XDG_CACHE_HOME', '~/.cache')
 DEFAULT_CACHE_DIR = Path(CACHE_HOME).expanduser() / 'visual-excuses'
 del CACHE_HOME

--- a/visual_excuses/const.py
+++ b/visual_excuses/const.py
@@ -1,0 +1,11 @@
+import os
+from pathlib import Path
+
+UBUNTU_EXCUSES_URL = (
+    "https://ubuntu-archive-team.ubuntu.com/proposed-migration/"
+    "update_excuses.yaml.xz"
+)
+
+CACHE_HOME = os.environ.get('XDG_CACHE_HOME', '~/.cache')
+DEFAULT_CACHE_DIR = Path(CACHE_HOME).expanduser() / 'visual-excuses'
+del CACHE_HOME

--- a/visual_excuses/ubuntu_excuses_cli.py
+++ b/visual_excuses/ubuntu_excuses_cli.py
@@ -14,7 +14,7 @@ def main():
     args = parser.parse_args()
 
     excuses = load_ubuntu_excuses(cache_dir=args.cache_dir)
-    ubuntu_teams = UbuntuTeamMapping()
+    ubuntu_teams = UbuntuTeamMapping(cache_dir=args.cache_dir)
 
     excuses = filter_excuses(excuses, args, ubuntu_teams)
     if excuses:

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -45,7 +45,7 @@ class CachedExcuses:
             return
 
         if response.status_code == 200:
-            if response.headers['ETag'] != self.etag.read_text():
+            if response.headers['ETag'] != headers.get('If-None-Match', ''):
                 print(f"Downloading {self.url}")
                 response = requests.get(
                     self.url, timeout=10, stream=True, headers=headers)

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import lzma
 from pathlib import Path
 from typing import List, Optional
@@ -40,13 +41,13 @@ class CachedExcuses:
         except requests.exceptions.HTTPError as e:
             print(
                 "Error accessing excuses yaml data from server: "
-                f"{e.response.status_code} - {e.response.reason}"
-                )
+                f"{e.response.status_code} - {e.response.reason}",
+                file=sys.stderr)
             return
 
         if response.status_code == 200:
             if response.headers['ETag'] != headers.get('If-None-Match', ''):
-                print(f"Downloading {self.url}")
+                print(f"Downloading {self.url}", file=sys.stderr)
                 response = requests.get(
                     self.url, timeout=10, stream=True, headers=headers)
                 response.raise_for_status()
@@ -82,5 +83,5 @@ def load_ubuntu_excuses(
     try:
         return load_excuses(cache.yaml)
     except FileNotFoundError:
-        print("No excuse data to consume")
+        print("No excuse data to consume", file=sys.stderr)
         return []

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -11,9 +11,10 @@ from .excuse import Excuse
 from .yaml_parser import load_excuses
 
 UBUNTU_EXCUSES_URL = (
-    "https://people.canonical.com/~ubuntu-archive/proposed-migration/"
-    "/update_excuses.yaml.xz"
+    "https://ubuntu-archive-team.ubuntu.com/proposed-migration/"
+    "update_excuses.yaml.xz"
 )
+
 CACHE_HOME = os.environ.get('XDG_CACHE_HOME', '~/.cache')
 DEFAULT_CACHE_DIR = Path(CACHE_HOME).expanduser() / 'visual-excuses'
 del CACHE_HOME

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import lzma
 from pathlib import Path
@@ -20,7 +19,7 @@ class CachedExcuses:
     CachedExcuses will only download new excuses if the version in the cached
     folder is outdated
     """
-    def __init__(self, url: str, cache_dir: Path):
+    def __init__(self, url: str, cache_dir: Path = DEFAULT_CACHE_DIR):
         self.url = url
         cache_dir.mkdir(parents=True, exist_ok=True)
         self.etag = cache_dir / "excuse.yaml.etag"

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -62,7 +62,6 @@ class CachedExcuses:
         else:
             raise ValueError(
                 f'Unexpected HTTP response status {response.status_code}')
-        print("Excuses Cache up to date!")
 
 
 def load_ubuntu_excuses(

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -29,9 +29,9 @@ class CachedExcuses:
     """
     def __init__(self, url: str, cache_dir: Path):
         self.url = url
-        self.directory = cache_dir
-        self.etag = self.directory / "ETag"
-        self.yaml = self.directory / "excuse.yaml"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        self.etag = cache_dir / "excuse.yaml.etag"
+        self.yaml = cache_dir / "excuse.yaml"
 
     def update(self):
         """
@@ -58,7 +58,6 @@ class CachedExcuses:
                 response = requests.get(
                     self.url, timeout=10, stream=True, headers=headers)
                 response.raise_for_status()
-                self.directory.mkdir(parents=True, exist_ok=True)
                 with (
                     lzma.LZMAFile(response.raw) as source,
                     self.yaml.open('wb') as target

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -7,17 +7,9 @@ from shutil import copyfileobj
 
 import requests
 
+from .const import DEFAULT_CACHE_DIR, UBUNTU_EXCUSES_URL
 from .excuse import Excuse
 from .yaml_parser import load_excuses
-
-UBUNTU_EXCUSES_URL = (
-    "https://ubuntu-archive-team.ubuntu.com/proposed-migration/"
-    "update_excuses.yaml.xz"
-)
-
-CACHE_HOME = os.environ.get('XDG_CACHE_HOME', '~/.cache')
-DEFAULT_CACHE_DIR = Path(CACHE_HOME).expanduser() / 'visual-excuses'
-del CACHE_HOME
 
 
 class CachedExcuses:

--- a/visual_excuses/ubuntu_excuses_loader.py
+++ b/visual_excuses/ubuntu_excuses_loader.py
@@ -38,7 +38,7 @@ class CachedExcuses:
         """
         headers = {}
         if self.etag.exists() and self.yaml.exists():
-            headers['ETag'] = self.etag.read_text()
+            headers['If-None-Match'] = self.etag.read_text()
             headers['If-Modified-Since'] = formatdate(
                 self.yaml.stat().st_mtime, usegmt=True)
         response = requests.get(

--- a/visual_excuses/ubuntu_teams.py
+++ b/visual_excuses/ubuntu_teams.py
@@ -1,17 +1,48 @@
+import json
 import requests
 from typing import List
+from email.utils import formatdate
+from shutil import copyfileobj
+from pathlib import Path
 
 from .const import DEFAULT_CACHE_DIR, UBUNTU_TEAMS_MAPPING_URL
 
 
 class UbuntuTeamMapping:
-    def __init__(self):
-        # retrieve distro teams and packages information
-        response = requests.get(UBUNTU_TEAMS_MAPPING_URL)
+    def __init__(self, cache_dir: Path):
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        self.etag = cache_dir / "teams.json.etag"
+        self.data = cache_dir / "teams.json"
+        self.update()
+
+    def update(self):
+        """
+        Check if the local cache requires refreshing
+        """
+        headers = {}
+        if self.etag.exists() and self.data.exists():
+            headers['If-None-Match'] = self.etag.read_text()
+            headers['If-Modified-Since'] = formatdate(
+                self.data.stat().st_mtime, usegmt=True)
+        response = requests.get(
+            UBUNTU_TEAMS_MAPPING_URL, timeout=10, stream=True,
+            headers=headers)
+        response.raise_for_status()
+
         if response.status_code == 200:
-            self.mapping = response.json()
+            print(f"Downloading {UBUNTU_TEAMS_MAPPING_URL}")
+            with self.data.open('wb') as target:
+                copyfileobj(response.raw, target)
+            self.etag.write_text(response.headers['ETag'])
+        elif response.status_code == 304:
+            # Not changed according to ETag/modified date
+            pass
         else:
-            raise RuntimeError("Failed to load Ubuntu team mapping.")
+            raise ValueError(
+                f'Unexpected HTTP response status {response.status_code}')
+
+        with self.data.open('r') as source:
+            self.mapping = json.load(source)
 
     def get_teams(self, package: str) -> List[str]:
         # return teams assigned to a single package

--- a/visual_excuses/ubuntu_teams.py
+++ b/visual_excuses/ubuntu_teams.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import requests
 from typing import List
@@ -30,7 +31,7 @@ class UbuntuTeamMapping:
         response.raise_for_status()
 
         if response.status_code == 200:
-            print(f"Downloading {UBUNTU_TEAMS_MAPPING_URL}")
+            print(f"Downloading {UBUNTU_TEAMS_MAPPING_URL}", file=sys.stderr)
             with self.data.open('wb') as target:
                 copyfileobj(response.raw, target)
             self.etag.write_text(response.headers['ETag'])

--- a/visual_excuses/ubuntu_teams.py
+++ b/visual_excuses/ubuntu_teams.py
@@ -10,7 +10,7 @@ from .const import DEFAULT_CACHE_DIR, UBUNTU_TEAMS_MAPPING_URL
 
 
 class UbuntuTeamMapping:
-    def __init__(self, cache_dir: Path):
+    def __init__(self, cache_dir: Path = DEFAULT_CACHE_DIR):
         cache_dir.mkdir(parents=True, exist_ok=True)
         self.etag = cache_dir / "teams.json.etag"
         self.data = cache_dir / "teams.json"

--- a/visual_excuses/ubuntu_teams.py
+++ b/visual_excuses/ubuntu_teams.py
@@ -1,9 +1,7 @@
 import requests
 from typing import List
 
-UBUNTU_TEAMS_MAPPING_URL = (
-    "http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.json"
-)
+from .const import DEFAULT_CACHE_DIR, UBUNTU_TEAMS_MAPPING_URL
 
 
 class UbuntuTeamMapping:

--- a/visual_excuses/visual_excuses_cmd.py
+++ b/visual_excuses/visual_excuses_cmd.py
@@ -14,7 +14,7 @@ def main():
     args = parser.parse_args()
 
     excuses = load_ubuntu_excuses()
-    ubuntu_teams = UbuntuTeamMapping()
+    ubuntu_teams = UbuntuTeamMapping(cache_dir=args.cache_dir)
 
     excuses = filter_excuses(excuses, args, ubuntu_teams)
     if excuses:


### PR DESCRIPTION
This fixes up the cache handling in ubuntu_excuses_loader (essentially working around the broken excuses web-server that ignores caching headers). It also adds caching for the teams JSON (using "proper" cache handling because *that* server actually works properly). Finally there's a quick commit I added to have status messages output to stderr (leaving the "interesting" output on stdout).