### PR TITLE
Fix multiverse typo in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ options:
   --inspect INSPECT     Get details about a specific package
   --name NAME           Regex to filter package names (case-insensitive)
   --component COMPONENT
-                        Archive component (main, restricted, universe, multivere)
+                        Archive component (main, restricted, universe, multiverse)
   --team TEAM           Show only packages subscribed by this Ubuntu team
   --ftbfs               Show only FTBFS packages
   --min-age MIN_AGE     Only include packages at least this many days old

--- a/visual_excuses/excuses_parser.py
+++ b/visual_excuses/excuses_parser.py
@@ -24,7 +24,7 @@ class ExcusesParser:
         self.parser.add_argument(
             "--component",
             type=str,
-            help="Archive component (main, restricted, universe, multivere)"
+            help="Archive component (main, restricted, universe, multiverse)"
         )
 
         self.parser.add_argument(


### PR DESCRIPTION
## Summary
- fix a typo of `multiverse` in the command parser
- update README usage documentation
